### PR TITLE
Add clean-merged command to remove merged local branches

### DIFF
--- a/src/CLI.ts
+++ b/src/CLI.ts
@@ -2,6 +2,7 @@
 
 import { Command, Option } from "commander";
 import { addReleaseNoteTemplate } from "./addReleaseNoteTemplate.js";
+import { cleanMerged } from "./cleanMerged.js";
 import { initLabel } from "./initLabel.js";
 import { postversion } from "./postversion.js";
 import { preversion } from "./preversion.js";
@@ -69,6 +70,15 @@ program
 	.option("--force", "overwrite existing file", false)
 	.action(async (options) => {
 		await addReleaseNoteTemplate(options.force);
+	});
+
+program
+	.command("clean-merged")
+	.description("clean up merged local branches")
+	.addOption(defaultBranchOption)
+	.addOption(dryRunOption)
+	.action(async (options) => {
+		await cleanMerged(options);
 	});
 
 program.parse();

--- a/src/cleanMerged.ts
+++ b/src/cleanMerged.ts
@@ -1,0 +1,40 @@
+import type { CommonCommandOptions } from "CommandOptions.js";
+import { execa } from "execa";
+
+export async function cleanMerged(
+	options: CommonCommandOptions,
+): Promise<void> {
+	const allBranchList = await execa("git", [
+		"branch",
+		"--merged",
+		options.defaultBranch,
+	]);
+
+	const allBranchNames = allBranchList.stdout.split("\n").map((branch) => {
+		return branch.trim();
+	});
+
+	//exclude current branch
+	const branchList = allBranchNames.filter((branch) => {
+		if (branch === options.defaultBranch) return false;
+		return !branch.trim().startsWith("*");
+	});
+
+	if (branchList.length === 0) {
+		console.log("No branches to clean up");
+		return;
+	}
+
+	if (options.dryRun) {
+		console.log("Dry run mode enabled. No branches will be deleted.");
+		console.log("Branches to be deleted:");
+		console.log(branchList.join("\n"));
+		return;
+	}
+
+	(async () => {
+		for (const branch of branchList) {
+			await execa("git", ["branch", "-d", branch]);
+		}
+	})();
+}


### PR DESCRIPTION
Introduce a command to clean up merged local branches, allowing users to easily manage their branch list. The implementation includes options for a dry run to preview branches that would be deleted without actually removing them.