### PR TITLE
Remove console log from openPullRequestWithBrowser function

### DIFF
--- a/src/postVersion/openPullRequestWithBrowser.ts
+++ b/src/postVersion/openPullRequestWithBrowser.ts
@@ -7,7 +7,6 @@ import { execa } from "execa";
  */
 export async function openPullRequestWithBrowser(output: string) {
 	const match = output.match(/\/pull\/(\d+)$/);
-	console.log(match);
 	if (match) {
 		const prNumber = match[1];
 		await execa("gh", ["browse", prNumber]);


### PR DESCRIPTION
Eliminate unnecessary console logging in the openPullRequestWithBrowser function to clean up the code.