### PR TITLE
Add help command execution to CI test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,3 +22,4 @@ jobs:
       - run: npm ci
       - run: npm run build
       - run: npm test
+      - run: node ./dist/CLI.js --help 


### PR DESCRIPTION
Execute the help command during the CI test workflow to ensure it runs correctly alongside the tests.