### PR TITLE
Update preversion logic to skip checkout and tests during dry run

### DIFF
--- a/__test__/preversion.spec.ts
+++ b/__test__/preversion.spec.ts
@@ -60,23 +60,25 @@ describe("preversion", () => {
 			"origin",
 			dryRunOptions.defaultBranch,
 		]);
-		expect(mockExeca).toHaveBeenCalledWith("git", [
+		expect(mockExeca).not.toHaveBeenCalledWith("git", [
 			"checkout",
 			dryRunOptions.defaultBranch,
 		]);
-		expect(mockExeca).toHaveBeenCalledWith("git", [
+		expect(mockExeca).not.toHaveBeenCalledWith("git", [
 			"pull",
 			"origin",
 			dryRunOptions.defaultBranch,
 		]);
-		expect(mockExeca).toHaveBeenCalledWith("npm", ["ci"]);
-		expect(mockExeca).toHaveBeenCalledWith("npm", [
+		expect(mockExeca).not.toHaveBeenCalledWith("npm", ["ci"]);
+		expect(mockExeca).not.toHaveBeenCalledWith("npm", [
 			"run",
 			"build",
 			"--if-present",
 		]);
 		expect(mockExeca).not.toHaveBeenCalledWith("npm", ["test"]);
-		expect(spyLog).toHaveBeenCalledWith("Dry run enabled. Skipping tests");
+		expect(spyLog).toHaveBeenCalledWith(
+			"Dry run enabled. Skipping checkout and tests.",
+		);
 
 		spyLog.mockRestore();
 	});

--- a/src/preversion.ts
+++ b/src/preversion.ts
@@ -7,15 +7,16 @@ interface PreversionOptions extends CommonCommandOptions {
 
 export async function preversion(options: PreversionOptions): Promise<void> {
 	await execa("git", ["fetch", "origin", options.defaultBranch]);
+
+	if (options.dryRun) {
+		console.log("Dry run enabled. Skipping checkout and tests.");
+		return;
+	}
+
 	await execa("git", ["checkout", options.defaultBranch]);
 	await execa("git", ["pull", "origin", options.defaultBranch]);
 	await execa("npm", ["ci"]);
 	await execa("npm", ["run", "build", "--if-present"]);
-
-	if (options.dryRun) {
-		console.log("Dry run enabled. Skipping tests");
-		return;
-	}
 
 	const testCommand = options.testCommand.split(" ");
 	const [command, ...args] = testCommand;


### PR DESCRIPTION
Revise the preversion function to avoid executing checkout and tests when a dry run is enabled, improving efficiency and clarity in the process. Update tests to reflect these changes.