### PR TITLE
Refactor tests to use spyOn for improved mocking

### DIFF
--- a/__test__/init/initLabel.spec.ts
+++ b/__test__/init/initLabel.spec.ts
@@ -1,35 +1,32 @@
-import { addPullRequestLabel } from "@/init/addPullRequestLabel.js";
-import { initLabel } from "@/init/index.js";
+import * as InitModule from "@/init/index.js";
+const { initLabel } = InitModule;
 import { describe, expect, it, vi } from "vitest";
-
-vi.mock("@/init/addPullRequestLabel.js");
 
 describe("initLabel", () => {
 	it('should add "release", "CICD", and "major" labels', async () => {
-		vi.mocked(addPullRequestLabel).mockImplementation(async () => {
-			return;
-		});
+		const mockedAddPullRequestLabel = vi
+			.spyOn(InitModule, "addPullRequestLabel")
+			.mockResolvedValue();
 
 		await initLabel();
 
-		expect(addPullRequestLabel).toHaveBeenCalledTimes(3);
-		expect(addPullRequestLabel).toHaveBeenCalledWith(
+		expect(mockedAddPullRequestLabel).toHaveBeenCalledTimes(3);
+		expect(mockedAddPullRequestLabel).toHaveBeenCalledWith(
 			"release",
 			"Pull request for the new release version",
 			"f29513",
 		);
-		expect(addPullRequestLabel).toHaveBeenCalledWith(
+		expect(mockedAddPullRequestLabel).toHaveBeenCalledWith(
 			"CICD",
 			"Pull request for maintaining the CI/CD environment",
 			"90cdf4",
 		);
-		expect(addPullRequestLabel).toHaveBeenCalledWith(
+		expect(mockedAddPullRequestLabel).toHaveBeenCalledWith(
 			"major",
 			"Pull request for the new major version",
 			"b60205",
 		);
 
-		vi.mocked(addPullRequestLabel).mockClear();
 		vi.resetAllMocks();
 	});
 });

--- a/__test__/postVersion/checkout.spec.ts
+++ b/__test__/postVersion/checkout.spec.ts
@@ -1,24 +1,25 @@
 import { checkout } from "@/postVersion/index.js";
+import * as UtilModule from "@/util/index.js";
 import { getTagBranchName } from "@/util/index.js";
 import { execa } from "execa";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("execa");
-vi.mock("@/util/index.js");
 
 describe("checkout", () => {
 	const execaMock = vi.mocked(execa);
-	const getTagBranchNameMock = vi.mocked(getTagBranchName);
 
 	beforeEach(() => {
 		execaMock.mockClear();
-		getTagBranchNameMock.mockClear();
+		vi.restoreAllMocks();
 	});
 
 	it("should checkout to a new branch using getTagBranchName", async () => {
-		getTagBranchNameMock.mockResolvedValue("release/v1.0.0");
+		vi.spyOn(UtilModule, "getTagBranchName").mockResolvedValue(
+			"release/v1.0.0",
+		);
 		await checkout();
-		expect(getTagBranchNameMock).toHaveBeenCalled();
+		expect(getTagBranchName).toHaveBeenCalled();
 		expect(execaMock).toHaveBeenCalledWith("git", [
 			"checkout",
 			"-b",

--- a/__test__/postVersion/pullRequest.spec.ts
+++ b/__test__/postVersion/pullRequest.spec.ts
@@ -1,14 +1,11 @@
-import { addPullRequestLabel } from "@/init/addPullRequestLabel.js";
-import { openPullRequestWithBrowser } from "@/postVersion/openPullRequestWithBrowser.js";
+import * as InitModule from "@/init/index.js";
+import * as OpenPullRequestWithBrowserModule from "@/postVersion/openPullRequestWithBrowser.js";
 import { pullRequest } from "@/postVersion/pullRequest.js";
-import { getTagBranchName } from "@/util/getTagVersion.js";
+import * as UtilModule from "@/util/index.js";
 import { ExecaError, execa } from "execa";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("execa");
-vi.mock("@/util/getTagVersion.js");
-vi.mock("@/init/addPullRequestLabel.js");
-vi.mock("@/postVersion/openPullRequestWithBrowser.js");
 
 describe("pullRequest", () => {
 	const defaultBranch = "main";
@@ -16,24 +13,19 @@ describe("pullRequest", () => {
 	const prUrl = "https://github.com/repo/pull/1";
 
 	const mockedExeca = vi.mocked(execa);
-	const mockedGetTagBranchName = vi.mocked(getTagBranchName);
-	const mockedAddPullRequestLabel = vi.mocked(addPullRequestLabel);
-	const mockedOpenPullRequestWithBrowser = vi.mocked(
-		openPullRequestWithBrowser,
-	);
 
 	beforeEach(() => {
 		vi.resetAllMocks();
 		mockedExeca.mockClear();
-		mockedGetTagBranchName.mockClear();
-		mockedAddPullRequestLabel.mockClear();
-		mockedOpenPullRequestWithBrowser.mockClear();
 	});
 
 	it("should create and auto-merge pull request when useAutoMerge is false", async () => {
-		mockedGetTagBranchName.mockResolvedValue(branchName);
-		mockedAddPullRequestLabel.mockResolvedValue();
-		mockedOpenPullRequestWithBrowser.mockResolvedValue(true);
+		vi.spyOn(UtilModule, "getTagBranchName").mockResolvedValue(branchName);
+		vi.spyOn(InitModule, "addPullRequestLabel").mockResolvedValue();
+		vi.spyOn(
+			OpenPullRequestWithBrowserModule,
+			"openPullRequestWithBrowser",
+		).mockResolvedValue(true);
 
 		mockedExeca
 			//@ts-ignore
@@ -44,9 +36,12 @@ describe("pullRequest", () => {
 	});
 
 	it("should create pull request and open browser when useAutoMerge is true", async () => {
-		mockedGetTagBranchName.mockResolvedValue(branchName);
-		mockedAddPullRequestLabel.mockResolvedValue();
-		mockedOpenPullRequestWithBrowser.mockResolvedValue(true);
+		vi.spyOn(UtilModule, "getTagBranchName").mockResolvedValue(branchName);
+		vi.spyOn(InitModule, "addPullRequestLabel").mockResolvedValue();
+		vi.spyOn(
+			OpenPullRequestWithBrowserModule,
+			"openPullRequestWithBrowser",
+		).mockResolvedValue(true);
 
 		mockedExeca
 			//@ts-ignore
@@ -59,9 +54,11 @@ describe("pullRequest", () => {
 	});
 
 	it("should handle merge error and throw if browser fails to open", async () => {
-		mockedGetTagBranchName.mockResolvedValue(branchName);
-		mockedAddPullRequestLabel.mockResolvedValue();
-		mockedOpenPullRequestWithBrowser.mockResolvedValue(true);
+		vi.spyOn(UtilModule, "getTagBranchName").mockResolvedValue(branchName);
+		vi.spyOn(InitModule, "addPullRequestLabel").mockResolvedValue();
+		const mockedOpenPullRequestWithBrowser = vi
+			.spyOn(OpenPullRequestWithBrowserModule, "openPullRequestWithBrowser")
+			.mockResolvedValue(true);
 
 		const error = new ExecaError();
 		error.stderr = "(enablePullRequestAutoMerge)";

--- a/__test__/postVersion/pullRequest.spec.ts
+++ b/__test__/postVersion/pullRequest.spec.ts
@@ -1,6 +1,6 @@
 import * as InitModule from "@/init/index.js";
-import * as OpenPullRequestWithBrowserModule from "@/postVersion/openPullRequestWithBrowser.js";
-import { pullRequest } from "@/postVersion/pullRequest.js";
+import * as PostVersionModule from "@/postVersion/index.js";
+const { pullRequest } = PostVersionModule;
 import * as UtilModule from "@/util/index.js";
 import { ExecaError, execa } from "execa";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -22,10 +22,9 @@ describe("pullRequest", () => {
 	it("should create and auto-merge pull request when useAutoMerge is false", async () => {
 		vi.spyOn(UtilModule, "getTagBranchName").mockResolvedValue(branchName);
 		vi.spyOn(InitModule, "addPullRequestLabel").mockResolvedValue();
-		vi.spyOn(
-			OpenPullRequestWithBrowserModule,
-			"openPullRequestWithBrowser",
-		).mockResolvedValue(true);
+		vi.spyOn(PostVersionModule, "openPullRequestWithBrowser").mockResolvedValue(
+			true,
+		);
 
 		mockedExeca
 			//@ts-ignore
@@ -38,10 +37,9 @@ describe("pullRequest", () => {
 	it("should create pull request and open browser when useAutoMerge is true", async () => {
 		vi.spyOn(UtilModule, "getTagBranchName").mockResolvedValue(branchName);
 		vi.spyOn(InitModule, "addPullRequestLabel").mockResolvedValue();
-		vi.spyOn(
-			OpenPullRequestWithBrowserModule,
-			"openPullRequestWithBrowser",
-		).mockResolvedValue(true);
+		vi.spyOn(PostVersionModule, "openPullRequestWithBrowser").mockResolvedValue(
+			true,
+		);
 
 		mockedExeca
 			//@ts-ignore
@@ -57,7 +55,7 @@ describe("pullRequest", () => {
 		vi.spyOn(UtilModule, "getTagBranchName").mockResolvedValue(branchName);
 		vi.spyOn(InitModule, "addPullRequestLabel").mockResolvedValue();
 		const mockedOpenPullRequestWithBrowser = vi
-			.spyOn(OpenPullRequestWithBrowserModule, "openPullRequestWithBrowser")
+			.spyOn(PostVersionModule, "openPullRequestWithBrowser")
 			.mockResolvedValue(true);
 
 		const error = new ExecaError();

--- a/__test__/postVersion/push.spec.ts
+++ b/__test__/postVersion/push.spec.ts
@@ -1,22 +1,22 @@
 import { push } from "@/postVersion/push.js";
-import { getTagBranchName } from "@/util/index.js";
+import * as UtilModule from "@/util/index.js";
 import { execa } from "execa";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("execa");
-vi.mock("@/util/index.js");
 
 describe("push", () => {
 	const mockedExeca = vi.mocked(execa);
-	const mockedGetTagBranchName = vi.mocked(getTagBranchName);
 
 	beforeEach(() => {
+		vi.restoreAllMocks();
 		mockedExeca.mockClear();
-		mockedGetTagBranchName.mockClear();
 	});
 
 	it("should call execa with the correct arguments", async () => {
-		mockedGetTagBranchName.mockResolvedValue("release-branch");
+		vi.spyOn(UtilModule, "getTagBranchName").mockResolvedValue(
+			"release-branch",
+		);
 		await push();
 		expect(mockedExeca).toHaveBeenCalledWith("git", [
 			"push",
@@ -27,7 +27,9 @@ describe("push", () => {
 	});
 
 	it("should retrieve the branch name before pushing", async () => {
-		mockedGetTagBranchName.mockResolvedValue("test-branch");
+		const mockedGetTagBranchName = vi
+			.spyOn(UtilModule, "getTagBranchName")
+			.mockResolvedValue("test-branch");
 		await push();
 		expect(mockedGetTagBranchName).toHaveBeenCalled();
 	});

--- a/__test__/postVersion/watchMerged.spec.ts
+++ b/__test__/postVersion/watchMerged.spec.ts
@@ -1,30 +1,29 @@
-import { getCheckStatus } from "@/postVersion/getCheckState.js";
+import * as GetCheckStatusModule from "@/postVersion/getCheckState.js";
 import { watchMerged } from "@/postVersion/watchMerged.js";
 import { execa } from "execa";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("execa");
-vi.mock("@/postVersion/getCheckState.js");
 
 describe("watchMerged", () => {
 	const mockPrURL = "https://github.com/owner/repo/pull/123";
-
 	const mockExeca = vi.mocked(execa);
-	const mockGetCheckStatus = vi.mocked(getCheckStatus);
 
 	beforeEach(() => {
 		mockExeca.mockClear();
-		mockGetCheckStatus.mockClear();
+		vi.restoreAllMocks();
 	});
 
 	it("should return 'failed' if check status is not 'success'", async () => {
-		mockGetCheckStatus.mockResolvedValue("error");
+		vi.spyOn(GetCheckStatusModule, "getCheckStatus").mockResolvedValue("error");
 		const result = await watchMerged(mockPrURL);
 		expect(result).toBe("failed");
 	});
 
 	it("should return 'merged' if execa stdout is 'MERGED'", async () => {
-		mockGetCheckStatus.mockResolvedValue("success");
+		vi.spyOn(GetCheckStatusModule, "getCheckStatus").mockResolvedValue(
+			"success",
+		);
 		//@ts-ignore
 		mockExeca.mockResolvedValue({ stdout: "MERGED" });
 		const result = await watchMerged(mockPrURL);
@@ -32,7 +31,9 @@ describe("watchMerged", () => {
 	});
 
 	it("should return 'closed' if execa stdout is 'CLOSED'", async () => {
-		mockGetCheckStatus.mockResolvedValue("success");
+		vi.spyOn(GetCheckStatusModule, "getCheckStatus").mockResolvedValue(
+			"success",
+		);
 		//@ts-ignore
 		mockExeca.mockResolvedValue({ stdout: "CLOSED" });
 		const result = await watchMerged(mockPrURL);
@@ -40,7 +41,9 @@ describe("watchMerged", () => {
 	});
 
 	it("should return undefined if execa stdout is neither 'MERGED' nor 'CLOSED'", async () => {
-		mockGetCheckStatus.mockResolvedValue("success");
+		vi.spyOn(GetCheckStatusModule, "getCheckStatus").mockResolvedValue(
+			"success",
+		);
 		//@ts-ignore
 		mockExeca.mockResolvedValue({ stdout: "OPEN" });
 		const result = await watchMerged(mockPrURL);

--- a/__test__/postversion.spec.ts
+++ b/__test__/postversion.spec.ts
@@ -16,7 +16,7 @@ describe("postversion", () => {
 	});
 
 	it("should log and return when dryRun is true", async () => {
-		const consoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+		const consoleLog = vi.spyOn(console, "log");
 		const result = { ...mockOptions, dryRun: true };
 		await postversion(result);
 		expect(consoleLog).toHaveBeenCalledWith("Dry run enabled");
@@ -67,14 +67,13 @@ describe("postversion", () => {
 		const mockOpenPullRequestWithBrowser = vi
 			.spyOn(PostVersionModule, "openPullRequestWithBrowser")
 			.mockResolvedValue(true);
+		const consoleLog = vi.spyOn(console, "log");
 
-		const consoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
-
-		await postversion(mockOptions);
+		await postversion({ ...mockOptions, dryRun: false });
 
 		expect(mockOpenPullRequestWithBrowser).toHaveBeenCalledWith(
 			"http://pr.url",
 		);
-		expect(consoleLog).not.toHaveBeenCalledWith("PR was successfully merged.");
+		expect(consoleLog).not.toBeCalled();
 	});
 });

--- a/__test__/postversion.spec.ts
+++ b/__test__/postversion.spec.ts
@@ -1,4 +1,4 @@
-import { afterAll, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import * as PostVersionModule from "@/postVersion/index.js";
 import { postversion } from "@/postversion.js";
@@ -11,7 +11,7 @@ describe("postversion", () => {
 		useAutoMerge: true,
 	};
 
-	afterAll(() => {
+	afterEach(() => {
 		vi.restoreAllMocks();
 	});
 

--- a/__test__/postversion.spec.ts
+++ b/__test__/postversion.spec.ts
@@ -4,8 +4,6 @@ import * as PostVersionModule from "@/postVersion/index.js";
 import { postversion } from "@/postversion.js";
 import * as ReleaseModule from "@/release.js";
 
-vi.mock("@/postVersion/index.js");
-
 describe("postversion", () => {
 	const mockOptions = {
 		dryRun: false,

--- a/__test__/previewRelease.spec.ts
+++ b/__test__/previewRelease.spec.ts
@@ -1,25 +1,26 @@
 import { previewRelease } from "@/previewRelease.js";
-import { getReleaseNoteBody, getTagVersion } from "@/util/index.js";
+import * as UtilModule from "@/util/index.js";
 import { execa } from "execa";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("execa");
-vi.mock("@/util/index.js");
 
 describe("previewRelease", () => {
 	const execaMock = vi.mocked(execa);
-	const getTagVersionMock = vi.mocked(getTagVersion);
-	const getReleaseNoteBodyMock = vi.mocked(getReleaseNoteBody);
 
-	beforeEach(() => {
+	afterEach(() => {
+		vi.restoreAllMocks();
 		execaMock.mockClear();
-		getTagVersionMock.mockClear();
-		getReleaseNoteBodyMock.mockClear();
 	});
 
 	it("should create and delete a release successfully", async () => {
-		getTagVersionMock.mockResolvedValue("v1.0.0");
-		getReleaseNoteBodyMock.mockResolvedValue("Release notes");
+		const getTagVersionMock = vi
+			.spyOn(UtilModule, "getTagVersion")
+			.mockResolvedValue("v1.0.0");
+		const getReleaseNoteBodyMock = vi
+			.spyOn(UtilModule, "getReleaseNoteBody")
+			.mockResolvedValue("Release notes");
+
 		const spyLog = vi.spyOn(console, "log").mockImplementation(() => {});
 		//@ts-ignore
 		execaMock.mockResolvedValueOnce({});
@@ -43,11 +44,10 @@ describe("previewRelease", () => {
 			"delete",
 			"v1.0.0-preview0",
 		]);
-		spyLog.mockRestore();
 	});
 
 	it("should handle execa failure during release creation", async () => {
-		getTagVersionMock.mockResolvedValue("v1.0.0");
+		vi.spyOn(UtilModule, "getTagVersion").mockResolvedValue("v1.0.0");
 		execaMock.mockRejectedValue(new Error("Failed to create release"));
 
 		await expect(previewRelease()).rejects.toThrow("Failed to create release");

--- a/__test__/release.spec.ts
+++ b/__test__/release.spec.ts
@@ -1,41 +1,51 @@
-import { release } from "@/release.js";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
-import {
-	checkMerged,
-	checkTagExists,
-	createDraft,
-	deleteBranch,
-	openDraft,
-	pushTags,
-} from "@/release/index.js";
-vi.mock("@/release/index.js");
+import { release } from "@/release.js";
+import * as ReleaseModule from "@/release/index.js";
 
 describe("release", () => {
-	const checkMergedMock = vi.mocked(checkMerged);
-	const checkTagExistsMock = vi.mocked(checkTagExists);
-	const createDraftMock = vi.mocked(createDraft);
-	const deleteBranchMock = vi.mocked(deleteBranch);
-	const openDraftMock = vi.mocked(openDraft);
-	const pushTagsMock = vi.mocked(pushTags);
-
-	beforeEach(() => {
-		checkMergedMock.mockRestore();
-		checkTagExistsMock.mockRestore();
-		pushTagsMock.mockRestore();
-		createDraftMock.mockRestore();
-		openDraftMock.mockRestore();
-		deleteBranchMock.mockRestore();
-
-		checkMergedMock.mockResolvedValue();
-		checkTagExistsMock.mockResolvedValue();
-		pushTagsMock.mockResolvedValue();
-		createDraftMock.mockResolvedValue();
-		openDraftMock.mockResolvedValue();
-		deleteBranchMock.mockResolvedValue();
+	afterEach(() => {
+		vi.restoreAllMocks();
 	});
 
+	const mockReleaseModule = () => {
+		const checkMergedMock = vi
+			.spyOn(ReleaseModule, "checkMerged")
+			.mockResolvedValue();
+		const checkTagExistsMock = vi
+			.spyOn(ReleaseModule, "checkTagExists")
+			.mockResolvedValue();
+		const createDraftMock = vi
+			.spyOn(ReleaseModule, "createDraft")
+			.mockResolvedValue();
+		const deleteBranchMock = vi
+			.spyOn(ReleaseModule, "deleteBranch")
+			.mockResolvedValue();
+		const openDraftMock = vi
+			.spyOn(ReleaseModule, "openDraft")
+			.mockResolvedValue();
+		const pushTagsMock = vi
+			.spyOn(ReleaseModule, "pushTags")
+			.mockResolvedValue();
+		return {
+			checkMergedMock,
+			checkTagExistsMock,
+			createDraftMock,
+			deleteBranchMock,
+			openDraftMock,
+			pushTagsMock,
+		};
+	};
+
 	it('should log "Dry run enabled" and return when options.dryRun is true', async () => {
+		const {
+			checkMergedMock,
+			checkTagExistsMock,
+			createDraftMock,
+			deleteBranchMock,
+			openDraftMock,
+			pushTagsMock,
+		} = mockReleaseModule();
 		const consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
 
 		const options = { dryRun: true, defaultBranch: "main" };
@@ -55,7 +65,14 @@ describe("release", () => {
 
 	it("should perform all release steps when options.dryRun is false", async () => {
 		const options = { dryRun: false, defaultBranch: "main" };
-
+		const {
+			checkMergedMock,
+			checkTagExistsMock,
+			createDraftMock,
+			deleteBranchMock,
+			openDraftMock,
+			pushTagsMock,
+		} = mockReleaseModule();
 		await release(options);
 
 		expect(checkMergedMock).toHaveBeenCalledWith(options.defaultBranch);

--- a/__test__/release/checkMerged.spec.ts
+++ b/__test__/release/checkMerged.spec.ts
@@ -1,21 +1,19 @@
 import { checkMerged } from "@/release/checkMerged.js";
-import { getTagBranchName } from "@/util/index.js";
+import * as UtilModule from "@/util/index.js";
 import { execa } from "execa";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("execa");
-vi.mock("@/util/index.js");
 
 describe("checkMerged", () => {
 	const defaultBranch = "main";
 	const branchName = "feature-branch";
 
 	const mockedExeca = vi.mocked(execa);
-	const mockedGetTagBranchName = vi.mocked(getTagBranchName);
 
 	beforeEach(() => {
+		vi.restoreAllMocks();
 		mockedExeca.mockClear();
-		mockedGetTagBranchName.mockClear();
 	});
 
 	it("should resolve if branch is merged into default branch", async () => {
@@ -23,7 +21,7 @@ describe("checkMerged", () => {
 		mockedExeca.mockResolvedValue({
 			stdout: `${defaultBranch}/${branchName}`,
 		});
-		mockedGetTagBranchName.mockResolvedValue(branchName);
+		vi.spyOn(UtilModule, "getTagBranchName").mockResolvedValue(branchName);
 
 		await expect(checkMerged(defaultBranch)).resolves.toBeUndefined();
 		expect(mockedExeca).toHaveBeenCalledWith("git", ["fetch", "origin"]);
@@ -39,7 +37,7 @@ describe("checkMerged", () => {
 		mockedExeca.mockResolvedValue({
 			stdout: `${defaultBranch}/${branchName}`,
 		});
-		mockedGetTagBranchName.mockResolvedValue("other-branch");
+		vi.spyOn(UtilModule, "getTagBranchName").mockResolvedValue("other-branch");
 
 		await expect(checkMerged(defaultBranch)).rejects.toThrow(
 			"Branch not merged",

--- a/__test__/release/checkTagExists.spec.ts
+++ b/__test__/release/checkTagExists.spec.ts
@@ -1,23 +1,21 @@
 import { checkTagExists } from "@/release/checkTagExists.js";
-import { getTagVersion } from "@/util/index.js";
+import * as UtilModule from "@/util/index.js";
 import { execa } from "execa";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("execa");
-vi.mock("@/util/index.js");
 
 describe("checkTagExists", () => {
 	const mockedExeca = vi.mocked(execa);
-	const mockedGetTagVersion = vi.mocked(getTagVersion);
 
 	beforeEach(() => {
+		vi.restoreAllMocks();
 		mockedExeca.mockClear();
-		mockedGetTagVersion.mockClear();
 	});
 
 	it("throws an error if the tag already exists", async () => {
 		const mockTag = "v1.0.0";
-		mockedGetTagVersion.mockResolvedValue(mockTag);
+		vi.spyOn(UtilModule, "getTagVersion").mockResolvedValue(mockTag);
 		//@ts-ignore
 		mockedExeca.mockResolvedValue({ stdout: `refs/tags/${mockTag}` });
 
@@ -26,7 +24,7 @@ describe("checkTagExists", () => {
 
 	it("does not throw an error if the tag does not exist", async () => {
 		const mockTag = "v1.0.0";
-		mockedGetTagVersion.mockResolvedValue(mockTag);
+		vi.spyOn(UtilModule, "getTagVersion").mockResolvedValue(mockTag);
 		//@ts-ignore
 		mockedExeca.mockResolvedValue({ stdout: "refs/tags/v0.9.0" });
 

--- a/__test__/release/createDraft.spec.ts
+++ b/__test__/release/createDraft.spec.ts
@@ -1,36 +1,25 @@
 import { createDraft } from "@/release/createDraft.js";
-import {
-	getPreviousTagVersion,
-	getReleaseNoteBody,
-	getTagVersion,
-	wrapDependencies,
-} from "@/util/index.js";
+import * as UtilModule from "@/util/index.js";
 import { execa } from "execa";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("execa");
-vi.mock("@/util/index.js");
 
 describe("createDraft", () => {
 	const execaMock = vi.mocked(execa);
-	const getTagVersionMock = vi.mocked(getTagVersion);
-	const getPreviousTagVersionMock = vi.mocked(getPreviousTagVersion);
-	const getReleaseNoteBodyMock = vi.mocked(getReleaseNoteBody);
-	const wrapDependenciesMock = vi.mocked(wrapDependencies);
 
 	beforeEach(() => {
+		vi.restoreAllMocks();
 		execaMock.mockClear();
-		getTagVersionMock.mockClear();
-		getPreviousTagVersionMock.mockClear();
-		getReleaseNoteBodyMock.mockClear();
-		wrapDependenciesMock.mockClear();
 	});
 
 	it("creates a draft release with previous tag", async () => {
-		getTagVersionMock.mockResolvedValue("v2.0.0");
-		getPreviousTagVersionMock.mockResolvedValue("v1.9.0");
-		getReleaseNoteBodyMock.mockResolvedValue("release body");
-		wrapDependenciesMock.mockReturnValue("wrapped body");
+		vi.spyOn(UtilModule, "getPreviousTagVersion").mockResolvedValue("v1.9.0");
+		vi.spyOn(UtilModule, "getTagVersion").mockResolvedValue("v2.0.0");
+		vi.spyOn(UtilModule, "getReleaseNoteBody").mockResolvedValue(
+			"release body",
+		);
+		vi.spyOn(UtilModule, "wrapDependencies").mockReturnValue("wrapped body");
 
 		await createDraft();
 
@@ -54,10 +43,12 @@ describe("createDraft", () => {
 	});
 
 	it("creates a draft release without previous tag", async () => {
-		getTagVersionMock.mockResolvedValue("v2.0.0");
-		getPreviousTagVersionMock.mockResolvedValue(undefined);
-		getReleaseNoteBodyMock.mockResolvedValue("release body");
-		wrapDependenciesMock.mockReturnValue(null);
+		vi.spyOn(UtilModule, "getPreviousTagVersion").mockResolvedValue(undefined);
+		vi.spyOn(UtilModule, "getTagVersion").mockResolvedValue("v2.0.0");
+		vi.spyOn(UtilModule, "getReleaseNoteBody").mockResolvedValue(
+			"release body",
+		);
+		vi.spyOn(UtilModule, "wrapDependencies").mockReturnValue(null);
 
 		await createDraft();
 

--- a/__test__/release/deleteBranch.spec.ts
+++ b/__test__/release/deleteBranch.spec.ts
@@ -2,25 +2,23 @@ import { execa } from "execa";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { deleteBranch } from "@/release/index.js";
-import { getTagBranchName } from "@/util/index.js";
+import * as UtilModule from "@/util/index.js";
 
 vi.mock("execa");
-vi.mock("@/util/index.js");
 
 describe("deleteBranch", () => {
 	const execaMock = vi.mocked(execa);
-	const getTagBranchNameMock = vi.mocked(getTagBranchName);
 
 	beforeEach(() => {
+		vi.restoreAllMocks();
 		execaMock.mockClear();
-		getTagBranchNameMock.mockClear();
 	});
 
 	it("calls git checkout on defaultBranch, deletes branch, pushes deletion, and pulls defaultBranch", async () => {
 		const branchName = "main";
 		const tagBranchName = "release-1.2.3";
 
-		getTagBranchNameMock.mockResolvedValue(tagBranchName);
+		vi.spyOn(UtilModule, "getTagBranchName").mockResolvedValue(tagBranchName);
 
 		await deleteBranch(branchName);
 

--- a/__test__/release/openDraft.spec.ts
+++ b/__test__/release/openDraft.spec.ts
@@ -1,24 +1,25 @@
-import { openDraft } from "@/release/index.js";
-import { getTagVersion } from "@/util/index.js";
 import { execa } from "execa";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { openDraft } from "@/release/index.js";
+import * as UtilModule from "@/util/index.js";
+
 vi.mock("execa");
-vi.mock("@/util/index.js");
 
 describe("openDraft", () => {
 	const mockedExeca = vi.mocked(execa);
-	const mockedGetTagVersion = vi.mocked(getTagVersion);
 
 	beforeEach(() => {
+		vi.restoreAllMocks();
 		mockedExeca.mockClear();
-		mockedGetTagVersion.mockClear();
 	});
 
 	it("should open the draft release in the browser with the correct tag", async () => {
 		// @ts-ignore
 		mockedExeca.mockImplementation(() => Promise.resolve());
-		mockedGetTagVersion.mockResolvedValue("v1.2.3");
+		const mockedGetTagVersion = vi
+			.spyOn(UtilModule, "getTagVersion")
+			.mockResolvedValue("v1.2.3");
 
 		await openDraft();
 		expect(mockedGetTagVersion).toHaveBeenCalledTimes(1);

--- a/__test__/release/pushTags.spec.ts
+++ b/__test__/release/pushTags.spec.ts
@@ -1,24 +1,23 @@
-import { pushTags } from "@/release/pushTags.js";
-import { getTagBranchName } from "@/util/index.js";
 import { execa } from "execa";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { pushTags } from "@/release/pushTags.js";
+import * as UtilModule from "@/util/index.js";
+
 vi.mock("execa");
-vi.mock("@/util/index.js");
 
 describe("pushTags", () => {
 	const mockedExeca = vi.mocked(execa);
-	const mockedGetTagBranchName = vi.mocked(getTagBranchName);
 
 	beforeEach(() => {
+		vi.restoreAllMocks();
 		mockedExeca.mockClear();
-		mockedGetTagBranchName.mockClear();
 	});
 
 	it("should push tags to origin with the correct branch name", async () => {
 		// @ts-ignore
 		mockedExeca.mockImplementation(() => Promise.resolve());
-		mockedGetTagBranchName.mockResolvedValue("mock-branch");
+		vi.spyOn(UtilModule, "getTagBranchName").mockResolvedValue("mock-branch");
 
 		await pushTags();
 		expect(execa).toHaveBeenCalledWith("git", [

--- a/__test__/runCommand.spec.ts
+++ b/__test__/runCommand.spec.ts
@@ -1,22 +1,13 @@
-import { cleanMerged } from "@/cleanMerged.js";
-import {
-	addReleaseNoteTemplate,
-	checkNpmTestCompletion,
-	initLabel,
-} from "@/init/index.js";
-import { postversion } from "@/postversion.js";
-import { preversion } from "@/preversion.js";
-import { previewRelease } from "@/previewRelease.js";
-import { release } from "@/release.js";
-import { runCommand } from "@/runCommand.js";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("@/preversion.js");
-vi.mock("@/postversion.js");
-vi.mock("@/release.js");
-vi.mock("@/previewRelease.js");
-vi.mock("@/cleanMerged.js");
-vi.mock("@/init/index.js");
+import * as cleanMergedModule from "@/cleanMerged.js";
+import * as InitModule from "@/init/index.js";
+import * as PostversionModule from "@/postversion.js";
+import * as PreversionModule from "@/preversion.js";
+import * as previewReleaseModule from "@/previewRelease.js";
+import * as ReleaseModule from "@/release.js";
+
+import { runCommand } from "@/runCommand.js";
 
 describe("runCommand", () => {
 	beforeEach(() => {
@@ -48,7 +39,9 @@ describe("runCommand", () => {
 	});
 
 	it("should run the command previersion", async () => {
-		const mockPreversion = vi.mocked(preversion).mockResolvedValue();
+		const mockPreversion = vi
+			.spyOn(PreversionModule, "preversion")
+			.mockResolvedValue();
 
 		process.argv = ["node", "cli.ts", "preversion"];
 		runCommand();
@@ -65,7 +58,9 @@ describe("runCommand", () => {
 	});
 
 	it("should run the command postversion", async () => {
-		const mockPostversion = vi.mocked(postversion).mockResolvedValue();
+		const mockPostversion = vi
+			.spyOn(PostversionModule, "postversion")
+			.mockResolvedValue();
 
 		process.argv = ["node", "cli.ts", "postversion"];
 		runCommand();
@@ -82,7 +77,7 @@ describe("runCommand", () => {
 	});
 
 	it("should run the command release", async () => {
-		const mockRelease = vi.mocked(release).mockResolvedValue();
+		const mockRelease = vi.spyOn(ReleaseModule, "release").mockResolvedValue();
 
 		process.argv = ["node", "cli.ts", "release"];
 		runCommand();
@@ -98,7 +93,9 @@ describe("runCommand", () => {
 	});
 
 	it("should run the command preview", async () => {
-		const mockPreview = vi.mocked(previewRelease).mockResolvedValue();
+		const mockPreview = vi
+			.spyOn(previewReleaseModule, "previewRelease")
+			.mockResolvedValue();
 
 		process.argv = ["node", "cli.ts", "preview"];
 		runCommand();
@@ -110,7 +107,9 @@ describe("runCommand", () => {
 	});
 
 	it("should run the command generate-release-template", async () => {
-		const mock = vi.mocked(addReleaseNoteTemplate).mockResolvedValue();
+		const mock = vi
+			.spyOn(InitModule, "addReleaseNoteTemplate")
+			.mockResolvedValue();
 
 		process.argv = ["node", "cli.ts", "generate-release-template"];
 		runCommand();
@@ -122,7 +121,7 @@ describe("runCommand", () => {
 	});
 
 	it("should run the command clean-merged", async () => {
-		const mock = vi.mocked(cleanMerged).mockResolvedValue();
+		const mock = vi.spyOn(cleanMergedModule, "cleanMerged").mockResolvedValue();
 
 		process.argv = ["node", "cli.ts", "clean-merged"];
 		runCommand();
@@ -138,12 +137,12 @@ describe("runCommand", () => {
 	});
 
 	it("should run the command init", async () => {
-		const mockInitLabel = vi.mocked(initLabel).mockResolvedValue();
+		const mockInitLabel = vi.spyOn(InitModule, "initLabel").mockResolvedValue();
 		const mockAddReleaseNoteTemplate = vi
-			.mocked(addReleaseNoteTemplate)
+			.spyOn(InitModule, "addReleaseNoteTemplate")
 			.mockResolvedValue();
 		const mockCheckNpmTestCompletion = vi
-			.mocked(checkNpmTestCompletion)
+			.spyOn(InitModule, "checkNpmTestCompletion")
 			.mockResolvedValue();
 
 		const spyLog = vi.spyOn(console, "log").mockReturnValue();

--- a/src/postVersion/pullRequest.ts
+++ b/src/postVersion/pullRequest.ts
@@ -1,7 +1,7 @@
 import { execa } from "execa";
 import { addPullRequestLabel } from "../init/index.js";
 import { getTagBranchName, isExecaErrorWithErrorCode } from "../util/index.js";
-import { openPullRequestWithBrowser } from "./openPullRequestWithBrowser.js";
+import { openPullRequestWithBrowser } from "./index.js";
 
 const releaseLabel = "release";
 


### PR DESCRIPTION
Refactor various test files to utilize `spyOn` for mocking module methods and clean up mocks, enhancing test reliability and readability. This change standardizes the mocking approach across the test suite.