### PR TITLE
feat: Add chores label and overwrite option for init command

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -6,18 +6,49 @@ changelog:
     - title: "🚨 Breaking Changes"
       labels:
         - major
-    - title : "🪛 Changes"
+    - title: "🪛 Changes"
       labels:
         - "*"
       exclude:
         labels:
           - major
           - dependencies
+          - documentation
+          - enhancement
+          - chores
+          - bug
           - release
           - CICD
+    - title: "❇️ Enhancement / New Features"
+      labels:
+        - enhancement
+      exclude:
+        labels:
+          - major
+    - title: "🐞 Bug Fixes"
+      labels:
+        - bug
+      exclude:
+        labels:
+          - major
+    - title: "🧹 Chores"
+      labels:
+        - chores
+      exclude:
+        labels:
+          - major
+    - title: "📄 Documentation"
+      labels:
+        - documentation
+      exclude:
+        labels:
+          - major
     - title: "🤖 CI / CD"
       labels:
         - CICD
+      exclude:
+        labels:
+          - major
     - title: "🔧 Dependencies"
       labels:
         - dependencies

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Commands:
   postversion [options]                create a pull request on GitHub
   release [options]                    push version tag and create a release on GitHub
   preview                              get release note from GitHub release
-  init                                 initialize release label and release note template
+  init [options]                       initialize release label and release note template
   generate-release-template [options]  generate release note template to .github directory
   help [command]                       display help for command
 ```

--- a/__test__/init/initLabel.spec.ts
+++ b/__test__/init/initLabel.spec.ts
@@ -22,6 +22,11 @@ describe("initLabel", () => {
 			"90cdf4",
 		);
 		expect(mockedAddPullRequestLabel).toHaveBeenCalledWith(
+			"chores",
+			"Pull request for miscellaneous maintenance tasks that do not affect the distributed package.",
+			"18DEE4",
+		);
+		expect(mockedAddPullRequestLabel).toHaveBeenCalledWith(
 			"major",
 			"Pull request for the new major version",
 			"b60205",

--- a/__test__/init/initLabel.spec.ts
+++ b/__test__/init/initLabel.spec.ts
@@ -10,7 +10,7 @@ describe("initLabel", () => {
 
 		await initLabel();
 
-		expect(mockedAddPullRequestLabel).toHaveBeenCalledTimes(3);
+		expect(mockedAddPullRequestLabel).toHaveBeenCalledTimes(4);
 		expect(mockedAddPullRequestLabel).toHaveBeenCalledWith(
 			"release",
 			"Pull request for the new release version",

--- a/__test__/runCommand.spec.ts
+++ b/__test__/runCommand.spec.ts
@@ -152,7 +152,7 @@ describe("runCommand", () => {
 
 		await vi.waitFor(() => {
 			expect(mockInitLabel).toBeCalledWith();
-			expect(mockAddReleaseNoteTemplate).toBeCalledWith();
+			expect(mockAddReleaseNoteTemplate).toBeCalledWith(false);
 			expect(mockCheckNpmTestCompletion).toBeCalled();
 		});
 

--- a/src/init/initLabel.ts
+++ b/src/init/initLabel.ts
@@ -14,6 +14,12 @@ export async function initLabel() {
 	);
 
 	await addPullRequestLabel(
+		"chores",
+		"Pull request for miscellaneous maintenance tasks that do not affect the distributed package.",
+		"18DEE4",
+	);
+
+	await addPullRequestLabel(
 		"major",
 		"Pull request for the new major version",
 		"b60205",

--- a/src/runCommand.ts
+++ b/src/runCommand.ts
@@ -61,9 +61,14 @@ export function runCommand() {
 	program
 		.command("init")
 		.description("initialize release label and release note template")
-		.action(async () => {
+		.option(
+			"--overwrite-template",
+			"overwrite existing release note template",
+			false,
+		)
+		.action(async (options) => {
 			await initLabel();
-			await addReleaseNoteTemplate();
+			await addReleaseNoteTemplate(options.overwriteTemplate);
 			await checkNpmTestCompletion();
 		});
 

--- a/template/release.yml
+++ b/template/release.yml
@@ -6,18 +6,49 @@ changelog:
     - title: "🚨 Breaking Changes"
       labels:
         - major
-    - title : "🪛 Changes"
+    - title: "🪛 Changes"
       labels:
         - "*"
       exclude:
         labels:
           - major
           - dependencies
+          - documentation
+          - enhancement
+          - chores
+          - bug
           - release
           - CICD
+    - title: "❇️ Enhancement / New Features"
+      labels:
+        - enhancement
+      exclude:
+        labels:
+          - major
+    - title: "🐞 Bug Fixes"
+      labels:
+        - bug
+      exclude:
+        labels:
+          - major
+    - title: "🧹 Chores"
+      labels:
+        - chores
+      exclude:
+        labels:
+          - major
+    - title: "📄 Documentation"
+      labels:
+        - documentation
+      exclude:
+        labels:
+          - major
     - title: "🤖 CI / CD"
       labels:
         - CICD
+      exclude:
+        labels:
+          - major
     - title: "🔧 Dependencies"
       labels:
         - dependencies


### PR DESCRIPTION
Summary:
This pull request introduces the following changes to the release process configuration and the `init` command.

Key Changes:

- Added and updated release note categories (.github/release.yml, template/release.yml) with their associated GitHub labels:
  - Enhancement / New Features: label `enhancement`
  - Bug Fixes: label `bug`
  - Chores: label `chores`
  - Documentation: label `documentation`
- Added the `--overwrite-template` option to the `init` command to allow overwriting existing release note templates.
- Updated related tests and documentation to reflect the changes in the `init` command.
