### PR TITLE
ci: add coverage reporting workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,31 @@
+name: "Pull Request Coverage Report and Comment"
+
+on:
+  pull_request:
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20.x"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests with coverage
+        run: npm run coverage
+
+      - name: Report Coverage
+        if: always()
+        uses: davelosert/vitest-coverage-report-action@v2

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
 	},
 	"scripts": {
 		"test": "vitest --run",
+		"coverage": "vitest run --coverage",
 		"preversion": "node ./dist/CLI.js preversion",
 		"postversion": "node ./dist/CLI.js postversion",
 		"release": "node ./dist/CLI.js release",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,5 +6,10 @@ export default defineConfig({
 		alias: {
 			"@": path.resolve(__dirname, "./src"),
 		},
+		coverage: {
+			reporter: ["text", "lcov", "json-summary", "json"],
+			reportOnFailure: true,
+			include: ["src/**/*.ts"],
+		},
 	},
 });


### PR DESCRIPTION
## Summary
- Add GitHub workflow for automated coverage reporting on pull requests
- Add `npm run coverage` command using vitest with coverage reporting
- Configure multiple coverage report formats (text, lcov, json-summary, json)
- Use vitest-coverage-report-action to automatically comment coverage results on PRs

## Changes
- **`.github/workflows/coverage.yml`**: New workflow that runs on PRs to generate and comment coverage reports
- **`package.json`**: Add `coverage` script for running tests with coverage
- **`vitest.config.ts`**: Configure coverage reporting with multiple formats and include only src files

## Test plan
- [x] Verify coverage workflow configuration is valid
- [x] Confirm vitest coverage configuration generates required report formats
- [x] Test that coverage script runs successfully locally

Closes #43

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automated code coverage reports are posted on pull requests, improving visibility into test coverage changes.

* **Chores**
  * Added a CI workflow to install dependencies, run tests with coverage, and comment results on pull requests.
  * Introduced an npm script to run tests with coverage locally.
  * Configured test coverage reporting with multiple formats and reporting on failures for TypeScript sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->