### PR TITLE
security: pin third-party GitHub Actions to commit SHA

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -28,4 +28,4 @@ jobs:
 
       - name: Report Coverage
         if: always()
-        uses: davelosert/vitest-coverage-report-action@v2
+        uses: davelosert/vitest-coverage-report-action@8ab049ff5a2c6e78f78af446329379b318544a1a # v2.8.3

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v2
+        uses: dependabot/fetch-metadata@08eff52bf64351f401fb50d4972fa95b9f2c2d1b # v2.4.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Enable auto-merge for Dependabot PRs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: "npm"
       - name: Setup Biome
-        uses: biomejs/setup-biome@v2
+        uses: biomejs/setup-biome@454fa0d884737805f48d7dc236c1761a0ac3cc13 # v2.6.0
       - run: npm ci
       - name: Run Biome
         run: biome ci


### PR DESCRIPTION
## Summary
Pin all third-party GitHub Actions to specific commit SHAs to prevent supply chain attacks and follow GitHub security best practices.

## Changes
- Pin `biomejs/setup-biome@v2` → `@454fa0d884737805f48d7dc236c1761a0ac3cc13` # v2.6.0
- Pin `dependabot/fetch-metadata@v2` → `@08eff52bf64351f401fb50d4972fa95b9f2c2d1b` # v2.4.0
- Pin `davelosert/vitest-coverage-report-action@v2` → `@8ab049ff5a2c6e78f78af446329379b318544a1a` # v2.8.3

## Security Benefits
- **Prevents tag tampering attacks**: Protects against malicious code injected into existing version tags
- **Immutable references**: Commit SHAs cannot be changed, ensuring reproducible builds
- **Supply chain protection**: Follows [GitHub's official security recommendations](https://docs.github.com/ja/actions/reference/security/secure-use#using-third-party-actions)

## Verification
All SHAs were obtained using GitHub's Commits API (`/commits/{tag}`) to ensure accuracy:
- ✅ Verified against actual release commits
- ✅ Comments preserve original version information for maintainability
- ✅ No functional changes to workflow behavior

## Test Plan
- [ ] Verify all workflows execute successfully with pinned SHAs
- [ ] Confirm no breaking changes in action behavior
- [ ] Validate security scanning passes

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned external CI actions to specific versions across coverage reporting, dependency auto-merge, and test setup to improve supply‑chain security, stability, and reproducibility.
  * No changes to application behavior or user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->