### PR TITLE
feat: add Node.js 24.x support to test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        node-version: [20.x, 22.x]
+        node-version: [20.x, 22.x, 24.x]
     steps:
       - uses: actions/checkout@v5
       - name: Use Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
## Summary
- Add Node.js 24.x to the CI/CD test matrix in GitHub Actions workflow
- Extends testing coverage to include the latest LTS version alongside existing 20.x and 22.x

## Test plan
- [ ] Verify CI tests pass on Node.js 24.x
- [ ] Confirm existing Node.js 20.x and 22.x tests continue to pass
- [ ] Check that all build steps complete successfully across all versions

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - No user-facing changes in this release.
- Chores
  - Expanded CI matrix to include Node.js 24.x alongside 20.x and 22.x, improving compatibility assurance with the latest runtime.
- Tests
  - Broadened test/build coverage across multiple Node.js versions; each matrix variant installs and runs on its specified Node version.
- Documentation
  - No documentation updates required.
- Refactor
  - No refactors included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->