### PR TITLE
feat: migrate npm publish workflow to OIDC authentication

### DIFF
--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -2,6 +2,11 @@ name: Publish to NPM
 on:
   release:
     types: [published]
+
+permissions:
+  id-token: write  # Required for OIDC authentication
+  contents: read   # Required for repository access
+
 jobs:
   npm-publish:
     runs-on: ubuntu-22.04
@@ -14,10 +19,10 @@ jobs:
           node-version: "20"
           cache: "npm"
           registry-url: "https://registry.npmjs.org"
+      - name: Upgrade npm to latest
+        run: npm install -g npm@latest
       - run: npm ci
       - name: build binary
         run: npm run build
       - name: Publish package on NPM 📦
         run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}


### PR DESCRIPTION
## Summary

Migrates the npm publish workflow from token-based authentication to OIDC authentication for enhanced security.

## Changes

- Add OIDC permissions (`id-token: write`, `contents: read`)
- Remove dependency on `NPM_PUBLISH_TOKEN` secret
- Add npm upgrade step to ensure latest npm version
- Use GitHub's built-in OIDC for NPM authentication

## Benefits

- **Enhanced Security**: Eliminates need for long-lived NPM tokens
- **Simplified Management**: No need to rotate or manage NPM_PUBLISH_TOKEN secrets
- **Better Compliance**: Uses GitHub's recommended OIDC authentication
- **Future-proof**: Aligns with npm's direction toward OIDC

## Testing

The workflow will be tested when a new release is published.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modernized the release publishing pipeline with stronger authentication, removing explicit token usage to enhance security.
  * Added an automatic npm upgrade step during publish to ensure the latest tooling and more reliable releases.
  * General improvements to the publishing workflow for better maintainability.

* **Notes**
  * No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->