### PR TITLE
fix: add repository metadata to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,5 +28,13 @@
 		"typescript": "^5.7.2"
 	},
 	"author": "MasatoMakino <makino.masato.g@gmail.com>",
-	"license": "MIT"
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/MasatoMakino/release-helper.git"
+	},
+	"bugs": {
+		"url": "https://github.com/MasatoMakino/release-helper/issues"
+	},
+	"homepage": "https://github.com/MasatoMakino/release-helper#readme"
 }


### PR DESCRIPTION
## Summary
- Add repository field with git+https URL format to package.json
- Add bugs field pointing to GitHub issues
- Add homepage field pointing to GitHub repository

## Problem
npm publishing was failing with provenance validation error:
```
Error verifying sigstore provenance bundle: Failed to validate repository information: package.json: "repository.url" is "", expected to match "https://github.com/MasatoMakino/release-helper"
```

## Solution
Added the required repository metadata fields to package.json to satisfy npm's sigstore provenance bundle validation requirements.

## Test plan
- [x] Verify package.json syntax is valid
- [ ] Test npm publishing workflow passes after merge

🤖 Generated with [Claude Code](https://claude.ai/code)